### PR TITLE
maintain sort order in read by ids

### DIFF
--- a/table.go
+++ b/table.go
@@ -986,16 +986,20 @@ func (table Table[T]) ReadCurrentEntityVersionID(ctx context.Context, entityID s
 // ReadEntities reads the current versions of the specified entities from the EntityRow.
 // If an entity does not exist, it will be omitted from the results.
 func (table Table[T]) ReadEntities(ctx context.Context, entityIDs []string) []T {
-	entities := make([]T, 0)
+	entities := make([]T, 0, len(entityIDs))
 	if len(entityIDs) == 0 {
 		return entities
 	}
+	entityIndex := make(map[string]T, len(entityIDs))
 	var batches [][]string
 	maxBatchSize := 10 // concurrent request limit
 	batches = Batch(entityIDs, maxBatchSize)
 	for _, batch := range batches {
 		batchSize := len(batch)
-		results := make(chan T, batchSize)
+		results := make(chan struct {
+			ID     string
+			entity T
+		}, batchSize)
 		var wg sync.WaitGroup
 		wg.Add(batchSize)
 		for _, entityID := range batch {
@@ -1004,15 +1008,23 @@ func (table Table[T]) ReadEntities(ctx context.Context, entityIDs []string) []T 
 				entity, err := table.ReadEntity(ctx, entityID)
 				if err != nil && err != ErrNotFound {
 					log.Printf("failed concurrent read %s-%s: %v\n", table.EntityType, entityID, err)
-				} else {
-					results <- entity
+				} else if err != ErrNotFound {
+					results <- struct {
+						ID     string
+						entity T
+					}{entityID, entity}
 				}
 			}(entityID)
 		}
 		wg.Wait()
 		close(results)
 		for entity := range results {
-			entities = append(entities, entity)
+			entityIndex[entity.ID] = entity.entity
+		}
+	}
+	for _, id := range entityIDs {
+		if val, ok := entityIndex[id]; ok {
+			entities = append(entities, val)
 		}
 	}
 	return entities
@@ -1024,15 +1036,17 @@ func (table Table[T]) ReadEntitiesAsJSON(ctx context.Context, entityIDs []string
 	if len(entityIDs) == 0 {
 		return nil
 	}
-	var entities bytes.Buffer
-	entities.WriteString("[")
-	var i int
+	entities := make([]string, 0, len(entityIDs))
+	entityIndex := make(map[string]string, len(entityIDs))
 	var batches [][]string
 	maxBatchSize := 10 // concurrent request limit
 	batches = Batch(entityIDs, maxBatchSize)
 	for _, batch := range batches {
 		batchSize := len(batch)
-		results := make(chan []byte, batchSize)
+		results := make(chan struct {
+			ID     string
+			entity string
+		}, batchSize)
 		var wg sync.WaitGroup
 		wg.Add(batchSize)
 		for _, entityID := range batch {
@@ -1041,23 +1055,26 @@ func (table Table[T]) ReadEntitiesAsJSON(ctx context.Context, entityIDs []string
 				entity, err := table.ReadEntityAsJSON(ctx, entityID)
 				if err != nil && err != ErrNotFound {
 					log.Printf("failed concurrent read as JSON %s-%s: %v\n", table.EntityType, entityID, err)
-				} else {
-					results <- entity
+				} else if err != ErrNotFound {
+					results <- struct {
+						ID     string
+						entity string
+					}{ID: entityID, entity: string(entity)}
 				}
 			}(entityID)
 		}
 		wg.Wait()
 		close(results)
 		for entity := range results {
-			if i > 0 {
-				entities.WriteString(",")
-			}
-			entities.Write(entity)
-			i++
+			entityIndex[entity.ID] = entity.entity
 		}
 	}
-	entities.WriteString("]")
-	return entities.Bytes()
+	for _, id := range entityIDs {
+		if val, ok := entityIndex[id]; ok {
+			entities = append(entities, val)
+		}
+	}
+	return []byte("[" + strings.Join(entities, ",") + "]")
 }
 
 // ReadEntity reads the current version of the specified entity.

--- a/table.go
+++ b/table.go
@@ -1012,7 +1012,7 @@ func (table Table[T]) ReadEntities(ctx context.Context, entityIDs []string) []T 
 					results <- struct {
 						ID     string
 						entity T
-					}{entityID, entity}
+					}{ID: entityID, entity: entity}
 				}
 			}(entityID)
 		}

--- a/table_test.go
+++ b/table_test.go
@@ -278,6 +278,27 @@ func TestTable_ReadEntities(t *testing.T) {
 	}
 }
 
+func TestTable_ReadEntities_missing(t *testing.T) {
+	ids := []string{v11.ID, "not found", v20.ID}
+	var entities = tableReader.ReadEntities(ctx, ids)
+	if len(entities) != 2 {
+		t.Fatalf("expected 2 entities, got %d", len(entities))
+	}
+	for _, e := range entities {
+		if v11.ID == e.ID {
+			if !reflect.DeepEqual(v11, e) {
+				t.Errorf("v11 and e are not equal")
+			}
+		} else if v20.ID == e.ID {
+			if !reflect.DeepEqual(v20, e) {
+				t.Errorf("v20 and e are not equal")
+			}
+		} else {
+			t.Errorf("unexpected entity ID: %s", e.ID)
+		}
+	}
+}
+
 func TestTable_ReadEntitiesAsJSON(t *testing.T) {
 	ids := []string{v11.ID, v20.ID}
 	jsonBytes := tableReader.ReadEntitiesAsJSON(ctx, ids)
@@ -290,6 +311,24 @@ func TestTable_ReadEntitiesAsJSON(t *testing.T) {
 	}
 	if !strings.Contains(jsonString, v20.ID) {
 		t.Errorf("expected JSON string to contain entity ID %s, got %s", v20.ID, jsonString)
+	}
+}
+
+func TestTable_ReadEntitiesAsJSON_missing(t *testing.T) {
+	ids := []string{v11.ID, "not found", v20.ID}
+	jsonBytes := tableReader.ReadEntitiesAsJSON(ctx, ids)
+	if len(jsonBytes) == 0 {
+		t.Fatalf("expected JSON bytes, got %d", len(jsonBytes))
+	}
+	jsonString := string(jsonBytes)
+	if !strings.Contains(jsonString, v11.ID) {
+		t.Errorf("expected JSON string to contain entity ID %s, got %s", v11.ID, jsonString)
+	}
+	if !strings.Contains(jsonString, v20.ID) {
+		t.Errorf("expected JSON string to contain entity ID %s, got %s", v20.ID, jsonString)
+	}
+	if strings.Contains(jsonString, ",,") || strings.Contains(jsonString, "[,") || strings.Contains(jsonString, ",]") {
+		t.Errorf("missing id produced malformed json with ',,' or '[,' or ',] %s", jsonString)
 	}
 }
 


### PR DESCRIPTION
The only thing I couldn't easily write a test for was that sorting was maintained with a list of IDs larger than the batch size.  There aren't enough test objects and since golang doesn't have overloading I couldn't easily add a method where you pass in the batch size without adding that to the interface and creating memtable versions of the same.  I'm not too concerned about it though.  Famous last words.