### PR TITLE
Support partition key labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.1
 	github.com/aws/aws-sdk-go-v2/config v1.13.1
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.4
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.6
 	github.com/aws/smithy-go v1.13.4
 	github.com/voxtechnica/tuid-go v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 h1:oRHDrwCTVT8ZXi4sr9
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19/go.mod h1:6Q0546uHDp421okhmmGfbxzq2hBqbXFNpi4k+Q1JnQA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.5 h1:ixotxbfTCFpqbuwFv/RcZwyzhkxPSYDYEMcj4niB5Uk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.5/go.mod h1:R3sWUqPcfXSiF/LSFJhjyJmpg9uV6yP2yv3YZZjldVI=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.4 h1:mN72saOOYAq2qBczDTi2LznXFf98lvimpSethXyVnOQ=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.4/go.mod h1:BiglbKCG56L8tmMnUEyEQo422BO9xnNR8vVHnOsByf8=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.6 h1:Ds0X66T0K1++l79cUD309YwrEcOHgA77O6EZy1vp0hg=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.6/go.mod h1:BiglbKCG56L8tmMnUEyEQo422BO9xnNR8vVHnOsByf8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.10 h1:dpiPHgmFstgkLG07KaYAewvuptq5kvo52xn7tVSrtrQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.10/go.mod h1:9cBNUHI2aW4ho0A5T87O294iPDuuUOSIEDjnd1Lq/z0=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.19 h1:V03dAtcAN4Qtly7H3/0B6m3t/cyl4FgyKFqK738fyJw=

--- a/record.go
+++ b/record.go
@@ -1,6 +1,7 @@
 package versionary
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -35,10 +36,20 @@ func (tv TextValue) ContainsAll(terms []string) bool {
 	return true
 }
 
+// String returns a string representation of the TextValue.
+func (tv TextValue) String() string {
+	return tv.Key + ": " + tv.Value
+}
+
 // NumValue represents a key-value pair where the value is a number.
 type NumValue struct {
 	Key   string  `json:"key"`
 	Value float64 `json:"value"`
+}
+
+// String returns a string representation of the NumValue.
+func (nv NumValue) String() string {
+	return fmt.Sprintf("%s: %g", nv.Key, nv.Value)
 }
 
 // Record is a struct that represents a single item in a database table. PartKeyValue and SortKeyValue


### PR DESCRIPTION
* Support optional partition key labels (key/value pairs) on wide rows.
* Support zero values for `TextValue` and `NumValue` if the key exists.